### PR TITLE
update for latest samd cores

### DIFF
--- a/src/usbmidi_pluggableusb.cpp
+++ b/src/usbmidi_pluggableusb.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2015-2018 UAB Vilniaus Blokas
  * All rights reserved.
  *
@@ -131,7 +131,7 @@ int UsbMidiModule::getInterface(uint8_t *interfaceCount)
 		D_MIDI_JACK_EP_SPC(0x03),
 	};
 
-	return USBD_SendControl(0, desc, sizeof(desc));
+	return USBDevice.sendControl(0, desc, sizeof(desc));
 }
 
 int UsbMidiModule::getDescriptor(USBSetup &setup)
@@ -179,7 +179,7 @@ int UsbMidiModule::_peek()
 
 void UsbMidiModule::_flush()
 {
-	USBD_Flush(getInEndpointId());
+	USBDevice.flush(getInEndpointId());
 }
 
 size_t UsbMidiModule::_write(uint8_t c)
@@ -187,7 +187,7 @@ size_t UsbMidiModule::_write(uint8_t c)
 	midi_event_t midiEvent;
 	if (m_midiToUsb.process(c, midiEvent))
 	{
-		USBD_Send(getInEndpointId(), &midiEvent, sizeof(midiEvent));
+		USBDevice.send(getInEndpointId(), &midiEvent, sizeof(midiEvent));
 	}
 
 	return 1;
@@ -198,7 +198,7 @@ void UsbMidiModule::_poll()
 	midi_event_t midiEvent;
 	int numReceived;
 
-	while (numReceived = USBD_Recv(getOutEndpointId(), &midiEvent, sizeof(midiEvent)))
+	while (numReceived = USBDevice.recv(getOutEndpointId(), &midiEvent, sizeof(midiEvent)))
 	{
 		// MIDI USB messages are 4 bytes in size.
 		if (numReceived != 4)


### PR DESCRIPTION
The current samd cores (1.5.7) no longer use USBD_* functions, but instead have a class,
USBDeviceClass, and a single global instance, USBDevice. These are defined in USBAPI.h

This commit updates the calls in usbmidi_pluggableusb.cpp to use this newer API.

This should help (fix?) with #4 
I'm successfully compiling and using this with an Adafruit Feather M0 Express (ATSAMD21G18).