### PR TITLE
Make USB enumeration work on Digistump cores

### DIFF
--- a/src/usbmidi_vusb.cpp
+++ b/src/usbmidi_vusb.cpp
@@ -280,9 +280,9 @@ static void midiUsbInit(void)
 #endif
 
 	// USB Reset by device only required on Watchdog Reset.
-	uint8_t j = 0;
+	volatile uint8_t j = 0;
 	while (--j) {   /* USB Reset by device only required on Watchdog Reset */
-		uint8_t i = 0;
+		volatile uint8_t i = 0;
 		while (--i);  /* delay >10ms for USB reset */
 	}
 


### PR DESCRIPTION
On the fork of the [Digistump core](https://github.com/ArminJo/DigistumpArduino), Digispark did not enumerate the MIDI device after the bootloader timed out. This commit is adapted from the DigiKeyboard library code and seems to make it work now